### PR TITLE
Save first shell call

### DIFF
--- a/lua/path-utils.lua
+++ b/lua/path-utils.lua
@@ -2,51 +2,42 @@ local module = {}
 
 -- Inspired by https://github.com/Guergeiro/clean-path.vim/blob/master/plugin/clean-path.vim
 function module.set_path()
-    -- Run system command and read result without newlines
-    -- Careful if command returns a newline delimited list
-    local handle = io.popen("git rev-parse --show-toplevel 2> /dev/null")
-    local result = string.gsub(handle:read("*a"), "\n", "")
+    local files_handle = io.popen("git ls-files | xargs dirname 2> /dev/null")
+    local files_result = files_handle:read("*a")
 
-    if result ~= "" then
-      local files_handle = io.popen("git ls-files " .. result .. " | xargs dirname | sort | uniq")
-      local files_result = files_handle:read("*a")
-
-      -- Create a list of all directories fd found
-      local paths = {}
-      -- Split string by matching all non-whitespace character groups
-      for v in string.gmatch(files_result, "%S+") do
-        if v ~= "" then
-          table.insert(paths, v)
-        end
+    -- Create a list of all directories fd found
+    local paths = {}
+    -- Split string by matching all non-whitespace character groups
+    for v in string.gmatch(files_result, "%S+") do
+      if v ~= "" then
+        table.insert(paths, v)
       end
-
-      local path = pcall(vim.bo,"path") or ""
-
-      if path ~= nil then
-          for v in string.gmatch(path, "[^,]+") do
-            if v ~= "" then
-              table.insert(paths, v)
-            end
-          end
-      end
-
-      -- Make list of directories unique
-      -- Includes both current path and new directories
-      local seen = {}
-      local unique = {}
-      for _, v in ipairs(paths) do
-        if not seen[v] then
-          table.insert(unique, v)
-          seen[v] = true
-        end
-      end
-
-      -- Set path and clean up
-      vim.bo.path = table.concat(unique, ",")
-      files_handle:close()
     end
 
-    handle:close()
+    local path = pcall(vim.bo,"path") or ""
+
+    if path ~= nil then
+        for v in string.gmatch(path, "[^,]+") do
+          if v ~= "" then
+            table.insert(paths, v)
+          end
+        end
+    end
+
+    -- Make list of directories unique
+    -- Includes both current path and new directories
+    local seen = {}
+    local unique = {}
+    for _, v in ipairs(paths) do
+      if not seen[v] then
+        table.insert(unique, v)
+        seen[v] = true
+      end
+    end
+
+    -- Set path and clean up
+    vim.bo.path = table.concat(unique, ",")
+    files_handle:close()
 end
 
 return module


### PR DESCRIPTION
Since I'm using `git ls-files` instead of `fd` here I can skip the first git call which should save some time for `BufEnter` if it's used like that. TL;DR: Make it faster.

Next step will be to write the boilerplate to make this run as a job